### PR TITLE
Update reading.md to have note on foreign-keys

### DIFF
--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -287,7 +287,8 @@ Would embed in the `client` key the row referenced with `client_id`.
 
 <div class="admonition note">
     <p class="admonition-title">Design Consideration</p>
-    <p>In order for this feature to work as expected after a schema change, PostgREST currently requires to be restarted.</p>
+    <p>In order for this feature to work as expected after a schema change, PostgREST currently requires a restart.</p>
+    <p>Additionally, in versions >=0.3.1.1 views containing sub-select statements as columns will not have foreign key relations matched. Sub-select statements may occur in a WHERE clause following a JOIN condition. In previous versions, foreign key relations in views with columns defined with sub-selects were sometimes incidentally recognized.  </p>
 </div>
 
 ### Response Format


### PR DESCRIPTION
Views with sub-selected columns will not have foreign keys automatically recognized after v 0.3.1.1, updated docs to reflect this. 
